### PR TITLE
Fix invalidating multiple urls

### DIFF
--- a/cloudflare
+++ b/cloudflare
@@ -949,7 +949,7 @@ invalidate)
 		zone_id=
 		for url in "$@"
 		do
-			urls="${urls:+,}\"$url\""
+			urls="${urls:+$urls,}\"$url\""
 			if [ -z "$zone_id" ]
 			then
 				if [[ "$url" =~ ^([^:]+:)?/*([^:/]+) ]]


### PR DESCRIPTION
This causes the existing `$urls` value to be appended instead of being replaced with `,"<last_url>"`.

Without this fix you will get error `E6007: Malformed JSON in request body` when invalidating more than one url.